### PR TITLE
Using the native session file handling

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -5,9 +5,9 @@ framework:
     #http_method_override: true
     #trusted_hosts: ~
     # https://symfony.com/doc/current/reference/configuration/framework.html#handler-id
-    session: ~
-    #    # The native PHP session handler will be used
-    #    handler_id: ~
+    session:
+        # The native PHP session handler will be used
+        handler_id: ~
     #esi: ~
     #fragments: ~
     php_errors:


### PR DESCRIPTION
With this config, Symfony will use the native session handling, instead of trying to store the files itself (e.g. into the `var/` directory of the project). This is the config we *intend* for you to have by default - but I realize now that the recipe (i.e. default config) is a bit confusing. Apologies - I'll see if we can improve that :)